### PR TITLE
Add request-scanning middleware, harden filter, rebrand to SpitFire

### DIFF
--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -6,8 +6,12 @@
 #   Repository Owner: bsaranga
 #   Repository:       PayloadInjectionFilter
 #   Workflow File:    dotnet-publish.yml
+#   Environment:      release   (optional, but recommended; must match the
+#                                job-level `environment: release` below)
 # and add a repository secret NUGET_USER set to your nuget.org username (the
-# profile name, NOT your email address).
+# profile name, NOT your email address). The `release` environment can also
+# be configured in GitHub (Settings -> Environments) with required reviewers
+# so a publish must be manually approved.
 
 name: Nuget Package Publish Workflow
 
@@ -19,6 +23,7 @@ jobs:
   build-and-publish:
 
     runs-on: ubuntu-latest
+    environment: release
 
     permissions:
       id-token: write   # required for GitHub to issue the OIDC token

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -1,21 +1,33 @@
-# This workflow will build a .NET project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
+# This workflow builds and publishes the NuGet package using Trusted Publishing
+# (OIDC), so no long-lived API key is stored in the repo.
+# See: https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing
+#
+# One-time setup on nuget.org (Account -> Trusted Publishing): add a policy with
+#   Repository Owner: bsaranga
+#   Repository:       PayloadInjectionFilter
+#   Workflow File:    dotnet-publish.yml
+# and add a repository secret NUGET_USER set to your nuget.org username (the
+# profile name, NOT your email address).
 
 name: Nuget Package Publish Workflow
 
 on:
-  pull_request:
+  push:
     branches: [ "main" ]
 
 jobs:
-  build:
+  build-and-publish:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      id-token: write   # required for GitHub to issue the OIDC token
+      contents: read
+
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 6.0.x
     - name: Restore dependencies
@@ -25,6 +37,11 @@ jobs:
     - name: Pack
       run: dotnet pack -o . -c Release
       working-directory: ./PayloadInjectionFilter
+    - name: NuGet login (OIDC -> short-lived API key)
+      uses: NuGet/login@v1
+      id: login
+      with:
+        user: ${{ secrets.NUGET_USER }}
     - name: Publish
-      run: dotnet nuget push *.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+      run: dotnet nuget push *.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
       working-directory: ./PayloadInjectionFilter

--- a/PayloadInjectionFilter/HelperExtensions.cs
+++ b/PayloadInjectionFilter/HelperExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using System.Reflection;
 using Microsoft.AspNetCore.Mvc.Filters;
 
-namespace Zone24x7PayloadExtensionFilter.HelperExtensions
+namespace SpitFirePayloadExtensionFilter.HelperExtensions
 {
     public static class HelperExtensions
     {

--- a/PayloadInjectionFilter/PayloadInjectionFilter.cs
+++ b/PayloadInjectionFilter/PayloadInjectionFilter.cs
@@ -5,10 +5,10 @@ using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.Options;
 using System.Collections;
-using Zone24x7PayloadExtensionFilter.HelperExtensions;
+using SpitFirePayloadExtensionFilter.HelperExtensions;
 using System.Net;
 
-namespace Zone24x7PayloadExtensionFilter
+namespace SpitFirePayloadExtensionFilter
 {
     /// <summary>
     /// This filter intercepts the requests before it
@@ -28,6 +28,13 @@ namespace Zone24x7PayloadExtensionFilter
         private int CurrentRecursionDepth;
         private List<string> CaughtMaliciousContent;
         private ActionExecutingContext CurrentContext;
+
+        /// <summary>
+        /// Tracks the reference-type instances on the current traversal path so that
+        /// cyclic object graphs (e.g. A -> B -> A) do not cause infinite recursion.
+        /// Reference equality is used so that distinct sibling instances are not skipped.
+        /// </summary>
+        private readonly HashSet<object> VisitedOnPath = new HashSet<object>(ReferenceEqualityComparer.Instance);
 
         private readonly ILogger<PayloadInjectionFilter> logger;
         private readonly IOptions<PayloadInjectionOptions> options;
@@ -89,9 +96,14 @@ namespace Zone24x7PayloadExtensionFilter
 
                 if (hasWhiteListedEntries)
                 {
-                    pathTemplate = context.ActionDescriptor.AttributeRouteInfo.Template;
-                    templateMatch = options.Value.WhiteListEntries.Select(w => w.PathTemplate).Contains(pathTemplate);
-                    whiteListIndex = (templateMatch) ? options.Value.WhiteListEntries.Select(w => w.PathTemplate).ToList().IndexOf(pathTemplate) : -1;
+                    // AttributeRouteInfo is null for convention-routed controllers; guard against it.
+                    pathTemplate = context.ActionDescriptor.AttributeRouteInfo?.Template;
+
+                    if (pathTemplate != null)
+                    {
+                        templateMatch = options.Value.WhiteListEntries.Select(w => w.PathTemplate).Contains(pathTemplate);
+                        whiteListIndex = (templateMatch) ? options.Value.WhiteListEntries.Select(w => w.PathTemplate).ToList().IndexOf(pathTemplate) : -1;
+                    }
                 }
 
                 if (context.IsOneOfAllowedHttpMethods(options.Value.AllowedHttpMethods!.Select(x => x.ToString()).Distinct().ToArray()))
@@ -100,12 +112,15 @@ namespace Zone24x7PayloadExtensionFilter
 
                     foreach (var argument in context.ActionArguments)
                     {
+                        // A nullable/optional bound parameter can be null; skip it instead of throwing.
+                        if (argument.Value == null) continue;
+
                         if (hasWhiteListedEntries && whiteListIndex != -1)
                         {
                             parameterMatch = options.Value.WhiteListEntries[whiteListIndex].ParameterName.Equals(argument.Key);
                             whiteListInitialCondition = parameterMatch && templateMatch;
                         }
-                        
+
                         var argumentType = argument.Value.GetType();
 
                         if (argumentType.IsString())
@@ -118,6 +133,7 @@ namespace Zone24x7PayloadExtensionFilter
                         {
                             foreach (var listItem in (argument.Value as IEnumerable)!)
                             {
+                                if (listItem == null) continue;
                                 Evaluate(listItem.GetType(), listItem, context, whiteListIndex, whiteListInitialCondition, ref PLACE_HOLDER_RECURSION_DEPTH);
                             }
                         }
@@ -142,39 +158,74 @@ namespace Zone24x7PayloadExtensionFilter
             {
                 if (arg != null && (!argType.IsValueType || argType.IsKeyValuePair()))
                 {
-                    IEnumerable<PropertyInfo> properties = argType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+                    // Cycle guard: if this exact instance is already on the current traversal
+                    // path, recursing again would loop forever. Track it for the duration of
+                    // this subtree and remove it on the way out so siblings are still scanned.
+                    bool tracked = !argType.IsValueType && VisitedOnPath.Add(arg);
+                    if (!tracked && !argType.IsValueType) return;
 
-                    if (properties.Any())
+                    try
                     {
+                        PropertyInfo[] properties = GetCachedProperties(argType);
+
                         foreach (var prop in properties)
                         {
                             isWhiteListedProperty = whiteListIndex != -1 && options.Value.WhiteListEntries[whiteListIndex].PropertyNames.Contains(prop.Name);
 
                             if (prop.IsString() && !(initialWhiteListCondition && isWhiteListedProperty))
                             {
-                                if (DetectDisallowedChars(prop.GetValue(arg) as string, options.Value.Pattern ?? DEFAULT_FILTER_PATTERN))
+                                var value = prop.GetValue(arg) as string;
+                                if (DetectDisallowedChars(value, options.Value.Pattern ?? DEFAULT_FILTER_PATTERN))
                                 {
-                                    ShortCircuit(context, prop.GetValue(arg) as string);
+                                    ShortCircuit(context, value);
+                                }
+                            }
+                            else if (prop.IsString() && initialWhiteListCondition && isWhiteListedProperty
+                                     && whiteListIndex != -1 && options.Value.WhiteListEntries[whiteListIndex].ExclusionPattern != null)
+                            {
+                                // The property is white-listed, but an ExclusionPattern is configured:
+                                // still short-circuit if the (otherwise allowed) value matches it.
+                                var value = prop.GetValue(arg) as string;
+                                if (DetectDisallowedChars(value, options.Value.WhiteListEntries[whiteListIndex].ExclusionPattern))
+                                {
+                                    ShortCircuit(context, value);
                                 }
                             }
                             else if (!prop.PropertyType.IsValueType)
                             {
+                                var value = prop.GetValue(arg);
+                                if (value == null) continue;
+
                                 if (prop.PropertyType.IsEnumerable())
                                 {
-                                    if (prop.GetValue(arg) != null)
+                                    foreach (var item in (value as IEnumerable))
                                     {
-                                        foreach (var item in (prop.GetValue(arg) as IEnumerable))
-                                            Evaluate(item.GetType(), item, context, whiteListIndex, initialWhiteListCondition, ref CurrentRecursionDepth);
+                                        if (item == null) continue;
+                                        Evaluate(item.GetType(), item, context, whiteListIndex, initialWhiteListCondition, ref CurrentRecursionDepth);
                                     }
                                 }
-                                else Evaluate(prop.PropertyType, prop.GetValue(arg), context, whiteListIndex, initialWhiteListCondition, ref CurrentRecursionDepth);
+                                else Evaluate(prop.PropertyType, value, context, whiteListIndex, initialWhiteListCondition, ref CurrentRecursionDepth);
                             }
                         }
+                    }
+                    finally
+                    {
+                        if (tracked) VisitedOnPath.Remove(arg);
                     }
                 }
             }
             else RecursionDepthExceeded(context);
         }
+
+        /// <summary>
+        /// Caches the public instance properties per <see cref="Type"/> so the reflection
+        /// metadata lookup is performed only once per type rather than on every request.
+        /// </summary>
+        private static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, PropertyInfo[]> PropertyCache
+            = new System.Collections.Concurrent.ConcurrentDictionary<Type, PropertyInfo[]>();
+
+        private static PropertyInfo[] GetCachedProperties(Type type)
+            => PropertyCache.GetOrAdd(type, t => t.GetProperties(BindingFlags.Public | BindingFlags.Instance));
 
         private bool DetectDisallowedChars(string input, Regex disallowedPattern)
         {

--- a/PayloadInjectionFilter/PayloadInjectionFilter.csproj
+++ b/PayloadInjectionFilter/PayloadInjectionFilter.csproj
@@ -3,10 +3,10 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-	<PackageId>Zone24x7.PayloadInjectionFilter</PackageId>
-	<Version>0.0.9</Version>
+	<PackageId>SpitFire.PayloadInjectionFilter</PackageId>
+	<Version>0.1.0</Version>
 	<Authors>Buwaneka Saranga</Authors>
-	<Company>Zone24x7 Inc.</Company>
+	<Company>SpitFire Inc.</Company>
 	<Product>PayloadInjectionFilter For ASPNET Core</Product>
 	<Description>
 		A reusable payload injection filter for ASP.NET Core. This can be used to short-circuit a request if it contains any malicious content as specified via a regex pattern.

--- a/PayloadInjectionFilter/PayloadInjectionFilterConfigurationExtensions.cs
+++ b/PayloadInjectionFilter/PayloadInjectionFilterConfigurationExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 
-namespace Zone24x7PayloadExtensionFilter
+namespace SpitFirePayloadExtensionFilter
 {
     /// <summary>
     /// Contains payload injection filter extensible methods

--- a/PayloadInjectionFilter/PayloadInjectionMiddleware.cs
+++ b/PayloadInjectionFilter/PayloadInjectionMiddleware.cs
@@ -1,0 +1,132 @@
+using System.Net;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace SpitFirePayloadExtensionFilter
+{
+    /// <summary>
+    /// Middleware that scans the raw request (query string and body) for disallowed content
+    /// before it reaches the endpoint pipeline. Because it runs before model binding it covers
+    /// MVC controllers, minimal APIs, Razor Pages and gRPC alike.
+    /// <para>
+    /// This is a defense-in-depth boundary check, not a substitute for output encoding,
+    /// parameterized queries or a dedicated WAF. Deny-listing characters such as
+    /// <c>&lt; &gt; &amp; ;</c> will reject some legitimate input — exclude such routes via
+    /// <see cref="PayloadInjectionMiddlewareOptions.ExcludedPaths"/>.
+    /// </para>
+    /// </summary>
+    public class PayloadInjectionMiddleware
+    {
+        private readonly RequestDelegate next;
+        private readonly ILogger<PayloadInjectionMiddleware> logger;
+        private readonly PayloadInjectionMiddlewareOptions options;
+        private readonly HashSet<string> methods;
+        private readonly Regex pattern;
+
+        public PayloadInjectionMiddleware(
+            RequestDelegate next,
+            IOptions<PayloadInjectionMiddlewareOptions> options,
+            ILogger<PayloadInjectionMiddleware> logger)
+        {
+            this.next = next;
+            this.logger = logger;
+            this.options = options.Value;
+            this.pattern = this.options.Pattern ?? new Regex(@"[<>\&;]");
+            this.methods = new HashSet<string>(
+                (this.options.AllowedHttpMethods ?? new List<HttpMethod>()).Select(m => m.Method),
+                StringComparer.OrdinalIgnoreCase);
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            var request = context.Request;
+
+            if (!methods.Contains(request.Method) || IsExcluded(request.Path))
+            {
+                await next(context);
+                return;
+            }
+
+            if (options.ScanQueryString && request.QueryString.HasValue)
+            {
+                // Decode so percent-encoded payloads (e.g. %3Cscript%3E) are caught too.
+                var query = Uri.UnescapeDataString(request.QueryString.Value!);
+                if (pattern.IsMatch(query))
+                {
+                    await ShortCircuitAsync(context, "query string");
+                    return;
+                }
+            }
+
+            if (options.ScanBody && HasBody(request))
+            {
+                if (request.ContentLength.HasValue && request.ContentLength.Value > options.MaxScannedBodyBytes)
+                {
+                    await RejectOversizedAsync(context);
+                    return;
+                }
+
+                var body = await ReadBodyAsync(request);
+                if (body != null && pattern.IsMatch(body))
+                {
+                    await ShortCircuitAsync(context, "request body");
+                    return;
+                }
+            }
+
+            await next(context);
+        }
+
+        private bool IsExcluded(PathString path)
+        {
+            if (options.ExcludedPaths == null || options.ExcludedPaths.Count == 0) return false;
+            return options.ExcludedPaths.Any(p => path.StartsWithSegments(p, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static bool HasBody(HttpRequest request)
+            => (request.ContentLength ?? 0) > 0 || request.Headers.ContainsKey("Transfer-Encoding");
+
+        private async Task<string> ReadBodyAsync(HttpRequest request)
+        {
+            // Buffer the body so it can be re-read by the endpoint after scanning.
+            request.EnableBuffering();
+
+            using var reader = new StreamReader(
+                request.Body,
+                Encoding.UTF8,
+                detectEncodingFromByteOrderMarks: false,
+                bufferSize: 1024,
+                leaveOpen: true);
+
+            var body = await reader.ReadToEndAsync();
+            request.Body.Position = 0;
+            return body;
+        }
+
+        private async Task ShortCircuitAsync(HttpContext context, string location)
+        {
+            logger.LogWarning(
+                "[PayloadInjectionMiddleware]:[Warning] Request short-circuited due to malicious content in the {Location}.",
+                location);
+
+            context.Response.Clear();
+            context.Response.StatusCode = options.ResponseStatusCode == 0 ? 400 : options.ResponseStatusCode;
+            context.Response.ContentType = options.ResponseContentType ?? "text/plain";
+            await context.Response.WriteAsync(
+                options.ResponseContentBody ?? "Request short-circuited due to malicious content.");
+        }
+
+        private async Task RejectOversizedAsync(HttpContext context)
+        {
+            logger.LogWarning("[PayloadInjectionMiddleware]:[Warning] Request body exceeds the scannable limit of {Limit} bytes.", options.MaxScannedBodyBytes);
+
+            context.Response.Clear();
+            context.Response.StatusCode = (int)HttpStatusCode.RequestEntityTooLarge;
+            context.Response.ContentType = "text/plain";
+            await context.Response.WriteAsync("Request body is too large to scan.");
+        }
+    }
+}

--- a/PayloadInjectionFilter/PayloadInjectionMiddlewareExtensions.cs
+++ b/PayloadInjectionFilter/PayloadInjectionMiddlewareExtensions.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SpitFirePayloadExtensionFilter
+{
+    /// <summary>
+    /// Registration helpers for the <see cref="PayloadInjectionMiddleware"/>.
+    /// </summary>
+    public static class PayloadInjectionMiddlewareExtensions
+    {
+        /// <summary>
+        /// Registers and configures the options used by <see cref="PayloadInjectionMiddleware"/>.
+        /// Call this in service configuration, then call <see cref="UsePayloadInjectionMiddleware"/>
+        /// in the request pipeline.
+        /// </summary>
+        public static IServiceCollection AddPayloadInjectionMiddleware(
+            this IServiceCollection services,
+            Action<PayloadInjectionMiddlewareOptions> configure = null)
+        {
+            if (configure != null) services.Configure(configure);
+            else services.Configure<PayloadInjectionMiddlewareOptions>(_ => { });
+
+            return services;
+        }
+
+        /// <summary>
+        /// Adds the payload injection scanning middleware to the request pipeline. Place this
+        /// early — before <c>UseRouting</c>/<c>MapControllers</c> — so malicious requests are
+        /// short-circuited before they reach any endpoint.
+        /// </summary>
+        public static IApplicationBuilder UsePayloadInjectionMiddleware(this IApplicationBuilder app)
+            => app.UseMiddleware<PayloadInjectionMiddleware>();
+    }
+}

--- a/PayloadInjectionFilter/PayloadInjectionMiddlewareOptions.cs
+++ b/PayloadInjectionFilter/PayloadInjectionMiddlewareOptions.cs
@@ -1,0 +1,71 @@
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Http;
+
+namespace SpitFirePayloadExtensionFilter
+{
+    /// <summary>
+    /// Options for the <see cref="PayloadInjectionMiddleware"/>.
+    /// <para>
+    /// Unlike the MVC action filter, the middleware runs before model binding and inspects
+    /// the raw request (query string and body) as text. It therefore works for any endpoint
+    /// type ASP.NET Core supports — MVC controllers, minimal APIs, Razor Pages and gRPC — at
+    /// the cost of not being able to target individual bound model properties. Use the
+    /// <see cref="ExcludedPaths"/> list to allow specific routes through unscanned.
+    /// </para>
+    /// </summary>
+    public class PayloadInjectionMiddlewareOptions
+    {
+        /// <summary>
+        /// Regex describing disallowed / malicious content. Defaults to <c>[&lt;&gt;\&amp;;]</c>.
+        /// </summary>
+        public Regex Pattern { get; set; } = new Regex(@"[<>\&;]");
+
+        /// <summary>
+        /// HTTP methods to scan. Defaults to POST, PUT and PATCH.
+        /// </summary>
+        public List<HttpMethod> AllowedHttpMethods { get; set; } = new List<HttpMethod>
+        {
+            HttpMethod.Post,
+            HttpMethod.Put,
+            HttpMethod.Patch,
+        };
+
+        /// <summary>
+        /// Status code returned when a request is short-circuited. Defaults to 400.
+        /// </summary>
+        public int ResponseStatusCode { get; set; } = 400;
+
+        /// <summary>
+        /// Content type of the short-circuit response. Defaults to <c>text/plain</c>.
+        /// </summary>
+        public string ResponseContentType { get; set; } = "text/plain";
+
+        /// <summary>
+        /// Body of the short-circuit response.
+        /// </summary>
+        public string ResponseContentBody { get; set; } = "Request short-circuited due to malicious content.";
+
+        /// <summary>
+        /// Whether to scan the request query string. Defaults to <c>true</c>.
+        /// </summary>
+        public bool ScanQueryString { get; set; } = true;
+
+        /// <summary>
+        /// Whether to scan the request body. Defaults to <c>true</c>.
+        /// </summary>
+        public bool ScanBody { get; set; } = true;
+
+        /// <summary>
+        /// Maximum body size (in bytes) that will be buffered and scanned. Requests with a
+        /// larger declared <c>Content-Length</c> are rejected with HTTP 413 rather than buffered,
+        /// which bounds the memory cost of scanning. Defaults to 30 MB.
+        /// </summary>
+        public long MaxScannedBodyBytes { get; set; } = 30L * 1024 * 1024;
+
+        /// <summary>
+        /// Request paths (prefix match) that should bypass scanning entirely. Useful for
+        /// endpoints that legitimately accept rich text / markup.
+        /// </summary>
+        public List<PathString> ExcludedPaths { get; set; } = new List<PathString>();
+    }
+}

--- a/PayloadInjectionFilter/PayloadInjectionOptions.cs
+++ b/PayloadInjectionFilter/PayloadInjectionOptions.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.RegularExpressions;
 
-namespace Zone24x7PayloadExtensionFilter
+namespace SpitFirePayloadExtensionFilter
 {
     /// <summary>
     /// Set fine-tuning options for the payload filter

--- a/PayloadInjectionFilter/ReadMe.md
+++ b/PayloadInjectionFilter/ReadMe.md
@@ -1,14 +1,37 @@
 # Payload Injection Filter for ASP.NET Core
-A reusable payload injection filter for ASP.NET Core. This can be used to short-circuit a request if it contains any malicious content as specified via a regex pattern.
+A reusable payload injection filter for ASP.NET Core. This can be used to short-circuit a request if it contains any malicious contents in the JSON payload or HTTP query parameters. The detection can be specified via a regex pattern.
 
 [![Build/Test Workflow](https://github.com/bsaranga/PayloadInjectionFilter/actions/workflows/dotnet-build.yml/badge.svg)](https://github.com/bsaranga/PayloadInjectionFilter/actions/workflows/dotnet-build.yml)
 [![Nuget Package Publish Workflow](https://github.com/bsaranga/PayloadInjectionFilter/actions/workflows/dotnet-publish.yml/badge.svg)](https://github.com/bsaranga/PayloadInjectionFilter/actions/workflows/dotnet-publish.yml)
 
-Available on [NuGet](https://www.nuget.org/packages/Zone24x7.PayloadInjectionFilter/)
+Available on [NuGet](https://www.nuget.org/packages/SpitFire.PayloadInjectionFilter/)
+
+The package ships **two interchangeable mechanisms**:
+
+| | MVC Action Filter | Middleware |
+|---|---|---|
+| Method | `AddPayloadInjectionFilter` | `AddPayloadInjectionMiddleware` / `UsePayloadInjectionMiddleware` |
+| Runs | after model binding | before routing & model binding |
+| Sees | the bound model object graph | the raw query string and request body |
+| Covers | MVC controllers only | controllers, **minimal APIs**, Razor Pages, gRPC |
+| Granularity | per-property white-listing | per-path exclusion |
+
+Use the **filter** when you want property-level white-listing inside MVC controllers. Use the **middleware** when you want a single boundary check that covers every endpoint type (including minimal APIs) and runs before any binding cost is incurred. They can also be combined.
+
+## Features
+
+1. Pattern based detection of malicious strings in JSON payloads
+2. Specify the HTTP methods on which the filter/middleware should execute
+3. Specify the short-circuit response by setting status code, content type and body
+4. Supports recursive payloads, including recursion limit specification, with built-in protection against cyclic object graphs
+5. Specific properties in specific endpoints can be white-listed (filter), or whole paths excluded (middleware)
+6. Optional per-entry `ExclusionPattern` that still rejects disallowed content inside otherwise white-listed properties
+
+> **Scope — read this first.** This is a *defense-in-depth* boundary check, not a complete security control. Deny-listing characters such as `< > & ;` does **not** by itself protect against XSS or SQL injection — the real defenses remain output encoding (Razor auto-encoding, `HtmlEncoder`) and parameterized queries / an ORM. Deny-listing will also reject some legitimate input (names with `&`, rich-text fields, etc.); white-list those properties or exclude those paths. Treat this library as one cheap layer in front of those primary defenses, not a replacement for a WAF.
 
 ## Usage
 
-The `AddPayloadInjectionFilter` method can be chained to the `AddControllers` method in a usual ASP.NET Core service configuration section. For the filter to work, you must specify the HTTP methods that it should operate on and the regex pattern that specifies a match for malicious content. The filter will check model bound bodies such as custom types and plain strings bound from query parameters.
+The `AddPayloadInjectionFilter` method can be chained to the `AddControllers` method in a usual ASP.NET Core service configuration section. For the filter to work, you must specify the HTTP methods that it should operate on and the regex pattern that specifies a match for malicious content. The filter will check model bound objects such as custom types and plain strings bound from query parameters.
 
 ```csharp
 public void ConfigureServices(IServiceCollection services)
@@ -28,7 +51,7 @@ public void ConfigureServices(IServiceCollection services)
 }
 ```
 
-By default, the filter will short-circuit the request and return a response with HTTP Status 400, and a plain text message saying, `Request short-circuited due to malicious content.`. This can be overridden as shown below,
+By default, the filter will short-circuit the request and return a response with an HTTP Status of 400, and a plain text message saying, `Request short-circuited due to malicious content.`. This can be overridden as shown below,
 
 ```csharp
 public void ConfigureServices(IServiceCollection services)
@@ -109,19 +132,108 @@ public void ConfigureServices(IServiceCollection services)
 }
 ```
 
-Further more, selected properties in the models bound selected API endpoints can be ignored by specification.
+Further more, selected properties in the models bound to selected API endpoints can be ignored by specification.
 
 ```csharp
-                cfg.WhiteListEntries = new List<WhiteListEntry>
-                {
-                    new WhiteListEntry
-                    {
-                        PathTemplate = "api/Services/appointmentSettings/{id}",
-                        ParameterName = "appointmentSetting",
-                        PropertyNames = new List<string>
-                        {
-                            nameof(ServiceAppointmentSetting.AdditoinalInformation)
-                        }
-                    }
-                };
+cfg.WhiteListEntries = new List<WhiteListEntry>
+{
+    new WhiteListEntry
+    {
+        PathTemplate = "api/Services/appointmentSettings/{id}",
+        ParameterName = "appointmentSetting",
+        PropertyNames = new List<string>
+        {
+            nameof(ServiceAppointmentSetting.AdditoinalInformation)
+        }
+    }
+};
 ```
+
+A white-listed property is normally skipped entirely. If you want to allow *most* content in a property but still block a narrower set of patterns, set an `ExclusionPattern` on the entry. The property is exempt from the global `Pattern`, but the request is still short-circuited when the value matches the `ExclusionPattern`:
+
+```csharp
+cfg.WhiteListEntries = new List<WhiteListEntry>
+{
+    new WhiteListEntry
+    {
+        PathTemplate = "api/Services/appointmentSettings/{id}",
+        ParameterName = "appointmentSetting",
+        PropertyNames = new List<string>
+        {
+            nameof(ServiceAppointmentSetting.AdditoinalInformation)
+        },
+        // Rich text with <p>, <strong> etc. is allowed, but <script> is still rejected.
+        ExclusionPattern = new Regex("<script", RegexOptions.IgnoreCase)
+    }
+};
+```
+
+## Using the middleware
+
+The middleware inspects the **raw** query string and request body before model binding, so it protects every endpoint type — including minimal APIs and Razor Pages — not just MVC controllers. Register the options in service configuration and add the middleware early in the pipeline:
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddPayloadInjectionMiddleware(cfg =>
+{
+    cfg.AllowedHttpMethods = new List<HttpMethod>
+    {
+        HttpMethod.Post,
+        HttpMethod.Put,
+        HttpMethod.Patch,
+    };
+
+    cfg.Pattern = new Regex(@"[<>\&;]");
+});
+
+var app = builder.Build();
+
+// Place it before UseRouting / MapControllers so malicious requests are
+// short-circuited before reaching any endpoint.
+app.UsePayloadInjectionMiddleware();
+
+app.MapControllers();
+app.MapPost("/minimal", (SomeModel model) => Results.Ok()); // also covered
+
+app.Run();
+```
+
+Because the middleware works on raw text it has no concept of model properties. Instead of per-property white-listing it supports **per-path exclusions** and toggles for what to scan:
+
+```csharp
+builder.Services.AddPayloadInjectionMiddleware(cfg =>
+{
+    cfg.Pattern = new Regex(@"[<>\&;]");
+
+    // Custom short-circuit response (defaults: 400, text/plain, standard message).
+    cfg.ResponseStatusCode = 400;
+    cfg.ResponseContentType = "application/json";
+    cfg.ResponseContentBody = JsonSerializer.Serialize(new { Error = "Malicious content found" });
+
+    // Choose what is scanned (both default to true).
+    cfg.ScanQueryString = true;
+    cfg.ScanBody = true;
+
+    // Bodies larger than this are rejected with 413 instead of being buffered (default 30 MB).
+    cfg.MaxScannedBodyBytes = 30L * 1024 * 1024;
+
+    // Routes that legitimately accept markup / rich text bypass scanning (prefix match).
+    cfg.ExcludedPaths = new List<PathString>
+    {
+        "/api/content/richtext"
+    };
+});
+```
+
+Notes:
+
+- The query string is URL-decoded before matching, so percent-encoded payloads such as `%3Cscript%3E` are caught.
+- The request body is buffered (`EnableBuffering`) and rewound, so downstream endpoints can read it as normal.
+- Only the HTTP methods in `AllowedHttpMethods` are scanned (POST, PUT, PATCH by default).
+
+## Reliability notes
+
+- **Cyclic object graphs** (e.g. `a.Nested = b; b.Nested = a;`) are detected via reference tracking on the traversal path, so the filter no longer stack-overflows when `MaxRecursionDepth` is left at the default `-1`.
+- **Null action arguments** (optional / unbound parameters and null collection items) are skipped instead of throwing.
+- Reflection metadata (`PropertyInfo`) is cached per type, so repeated requests do not re-enumerate properties on every call.

--- a/PayloadInjectionFilter_Tests/DataDrivenTests.cs
+++ b/PayloadInjectionFilter_Tests/DataDrivenTests.cs
@@ -10,7 +10,7 @@ using PayloadInjectionFilter_Tests.CustomTypes;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
-using Zone24x7PayloadExtensionFilter;
+using SpitFirePayloadExtensionFilter;
 using Microsoft.AspNetCore.Routing;
 using Newtonsoft.Json;
 

--- a/PayloadInjectionFilter_Tests/HelperTests.cs
+++ b/PayloadInjectionFilter_Tests/HelperTests.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Routing;
 using PayloadInjectionFilter_Tests.CustomTypes;
-using Zone24x7PayloadExtensionFilter.HelperExtensions;
+using SpitFirePayloadExtensionFilter.HelperExtensions;
 
 namespace PayloadInjectionFilter_Tests
 {

--- a/PayloadInjectionFilter_Tests/PayloadInjectionFilterTests.cs
+++ b/PayloadInjectionFilter_Tests/PayloadInjectionFilterTests.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Zone24x7PayloadExtensionFilter;
+using SpitFirePayloadExtensionFilter;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.Routing;
@@ -786,6 +786,122 @@ namespace PayloadInjectionFilter_Tests
             Assert.IsFalse(sanitizationFilter.HasShortCircuited);
             Assert.IsTrue(sanitizationFilter.RecursionDepthHasExceeded);
             Assert.That((sanitizationFilter.GetCurrentContext().Result as ContentResult).StatusCode, Is.EqualTo(413));
+        }
+
+        [TestCase("POST")]
+        public void Does_Not_Throw_On_Null_Argument_Value(string httpMethod)
+        {
+            var mockLogger = new Mock<ILogger<PayloadInjectionFilter>>();
+            var mockOptions = new Mock<IOptions<PayloadInjectionOptions>>();
+
+            mockOptions.Setup(x => x.Value).Returns(new PayloadInjectionOptions
+            {
+                AllowedHttpMethods = new List<HttpMethod> { HttpMethod.Put, HttpMethod.Post, HttpMethod.Patch },
+                Pattern = new Regex(@"[<>\&;]")
+            });
+
+            var sanitizationFilter = new PayloadInjectionFilter(mockOptions.Object, mockLogger.Object);
+            var defaultHttpContext = new DefaultHttpContext();
+            defaultHttpContext.Request.Method = httpMethod;
+
+            // An optional / unbound parameter surfaces as a null action argument value.
+            var bodyWithNull = new Dictionary<string, object>
+            {
+                { "optionalModel", null }
+            };
+
+            var ctrlActionDescriptor = new ControllerActionDescriptor { ControllerName = "Service" };
+            var actionContext = new ActionContext(defaultHttpContext, new RouteData(), ctrlActionDescriptor, new ModelStateDictionary());
+            var actionExecutingContext = new ActionExecutingContext(actionContext, new List<IFilterMetadata>(), bodyWithNull, null);
+
+            Assert.DoesNotThrow(() => sanitizationFilter.OnActionExecuting(actionExecutingContext));
+            Assert.That(sanitizationFilter.HasShortCircuited, Is.False);
+        }
+
+        [TestCase("POST")]
+        public void Terminates_On_Cyclic_Object_Graph(string httpMethod)
+        {
+            var mockLogger = new Mock<ILogger<PayloadInjectionFilter>>();
+            var mockOptions = new Mock<IOptions<PayloadInjectionOptions>>();
+
+            mockOptions.Setup(x => x.Value).Returns(new PayloadInjectionOptions
+            {
+                AllowedHttpMethods = new List<HttpMethod> { HttpMethod.Put, HttpMethod.Post, HttpMethod.Patch },
+                Pattern = new Regex(@"[<>\&;]")
+                // MaxRecursionDepth left at the default (-1 / infinite) on purpose.
+            });
+
+            var sanitizationFilter = new PayloadInjectionFilter(mockOptions.Object, mockLogger.Object);
+            var defaultHttpContext = new DefaultHttpContext();
+            defaultHttpContext.Request.Method = httpMethod;
+
+            // Build a reference cycle: a -> b -> a
+            var a = new RecursiveType { Text1 = "safe", Text2 = "safe" };
+            var b = new RecursiveType { Text1 = "<unsafe/>", Text2 = "safe", Nested = a };
+            a.Nested = b;
+
+            var cyclicBody = new Dictionary<string, object> { { "cyclic", a } };
+
+            var ctrlActionDescriptor = new ControllerActionDescriptor { ControllerName = "Service" };
+            var actionContext = new ActionContext(defaultHttpContext, new RouteData(), ctrlActionDescriptor, new ModelStateDictionary());
+            var actionExecutingContext = new ActionExecutingContext(actionContext, new List<IFilterMetadata>(), cyclicBody, null);
+
+            // Without cycle detection this would StackOverflow with infinite recursion depth.
+            Assert.DoesNotThrow(() => sanitizationFilter.OnActionExecuting(actionExecutingContext));
+            Assert.That(sanitizationFilter.HasShortCircuited, Is.True);
+        }
+
+        [Test]
+        public void Applies_ExclusionPattern_To_Whitelisted_Property()
+        {
+            var mockLogger = new Mock<ILogger<PayloadInjectionFilter>>();
+            var mockOptions = new Mock<IOptions<PayloadInjectionOptions>>();
+
+            mockOptions.Setup(x => x.Value).Returns(new PayloadInjectionOptions
+            {
+                AllowedHttpMethods = new List<HttpMethod> { HttpMethod.Put, HttpMethod.Post, HttpMethod.Patch },
+                Pattern = new Regex(@"[<>\&;]"),
+                WhiteListEntries = new List<WhiteListEntry>
+                {
+                    new WhiteListEntry
+                    {
+                        PathTemplate = "appointmentSettings/{id}",
+                        ParameterName = "legitimateRichText",
+                        PropertyNames = new List<string> { nameof(LegitimateRichText.AllowedRichText) },
+                        // Even within a white-listed field, <script> tags remain disallowed.
+                        ExclusionPattern = new Regex(@"<script", RegexOptions.IgnoreCase)
+                    }
+                }
+            });
+
+            var sanitizationFilter = new PayloadInjectionFilter(mockOptions.Object, mockLogger.Object);
+            var defaultHttpContext = new DefaultHttpContext();
+            defaultHttpContext.Request.Method = "PUT";
+
+            var body = new Dictionary<string, object>
+            {
+                {
+                    "legitimateRichText",
+                    new LegitimateRichText
+                    {
+                        ModelId = 1,
+                        AllowedRichText = "<p>fine</p><script>alert(1)</script>"
+                    }
+                }
+            };
+
+            var ctrlActionDescriptor = new ControllerActionDescriptor
+            {
+                ControllerName = "Service",
+                AttributeRouteInfo = new AttributeRouteInfo { Template = "appointmentSettings/{id}" }
+            };
+
+            var actionContext = new ActionContext(defaultHttpContext, new RouteData(), ctrlActionDescriptor, new ModelStateDictionary());
+            var actionExecutingContext = new ActionExecutingContext(actionContext, new List<IFilterMetadata>(), body, null);
+
+            sanitizationFilter.OnActionExecuting(actionExecutingContext);
+
+            Assert.That(sanitizationFilter.HasShortCircuited, Is.True);
         }
 
         [TestCase("PATCH")]

--- a/PayloadInjectionFilter_Tests/PayloadInjectionMiddlewareTests.cs
+++ b/PayloadInjectionFilter_Tests/PayloadInjectionMiddlewareTests.cs
@@ -1,0 +1,143 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using SpitFirePayloadExtensionFilter;
+
+namespace PayloadInjectionFilter_Tests
+{
+    [TestFixture]
+    public class PayloadInjectionMiddlewareTests
+    {
+        private static PayloadInjectionMiddleware Build(PayloadInjectionMiddlewareOptions opts, RequestDelegate next)
+        {
+            var logger = new Mock<ILogger<PayloadInjectionMiddleware>>();
+            var options = new Mock<IOptions<PayloadInjectionMiddlewareOptions>>();
+            options.Setup(x => x.Value).Returns(opts);
+            return new PayloadInjectionMiddleware(next, options.Object, logger.Object);
+        }
+
+        private static DefaultHttpContext ContextWith(string method, string body = null, string queryString = null)
+        {
+            var ctx = new DefaultHttpContext();
+            ctx.Request.Method = method;
+            ctx.Response.Body = new MemoryStream();
+
+            if (queryString != null) ctx.Request.QueryString = new QueryString(queryString);
+
+            if (body != null)
+            {
+                var bytes = Encoding.UTF8.GetBytes(body);
+                ctx.Request.Body = new MemoryStream(bytes);
+                ctx.Request.ContentLength = bytes.Length;
+            }
+
+            return ctx;
+        }
+
+        [Test]
+        public async Task ShortCircuits_Malicious_Body()
+        {
+            var nextCalled = false;
+            var middleware = Build(new PayloadInjectionMiddlewareOptions(), _ => { nextCalled = true; return Task.CompletedTask; });
+
+            var ctx = ContextWith("POST", body: "{\"name\":\"<script>alert(1)</script>\"}");
+            await middleware.InvokeAsync(ctx);
+
+            Assert.That(nextCalled, Is.False);
+            Assert.That(ctx.Response.StatusCode, Is.EqualTo(400));
+        }
+
+        [Test]
+        public async Task Allows_Clean_Body_And_Body_Is_Rewound_For_Downstream()
+        {
+            string seenByEndpoint = null;
+            var middleware = Build(new PayloadInjectionMiddlewareOptions(), async ctx =>
+            {
+                using var reader = new StreamReader(ctx.Request.Body);
+                seenByEndpoint = await reader.ReadToEndAsync();
+            });
+
+            var ctx = ContextWith("POST", body: "{\"name\":\"perfectly fine\"}");
+            await middleware.InvokeAsync(ctx);
+
+            Assert.That(ctx.Response.StatusCode, Is.EqualTo(200));
+            Assert.That(seenByEndpoint, Is.EqualTo("{\"name\":\"perfectly fine\"}"));
+        }
+
+        [Test]
+        public async Task ShortCircuits_Malicious_QueryString()
+        {
+            var nextCalled = false;
+            var middleware = Build(new PayloadInjectionMiddlewareOptions(), _ => { nextCalled = true; return Task.CompletedTask; });
+
+            var ctx = ContextWith("POST", queryString: "?q=%3Cscript%3E");
+            await middleware.InvokeAsync(ctx);
+
+            Assert.That(nextCalled, Is.False);
+            Assert.That(ctx.Response.StatusCode, Is.EqualTo(400));
+        }
+
+        [Test]
+        public async Task Does_Not_Scan_Disallowed_Methods()
+        {
+            var nextCalled = false;
+            var middleware = Build(new PayloadInjectionMiddlewareOptions(), _ => { nextCalled = true; return Task.CompletedTask; });
+
+            var ctx = ContextWith("GET", body: "<script>");
+            await middleware.InvokeAsync(ctx);
+
+            Assert.That(nextCalled, Is.True);
+        }
+
+        [Test]
+        public async Task Skips_Excluded_Paths()
+        {
+            var nextCalled = false;
+            var opts = new PayloadInjectionMiddlewareOptions { ExcludedPaths = { "/api/richtext" } };
+            var middleware = Build(opts, _ => { nextCalled = true; return Task.CompletedTask; });
+
+            var ctx = ContextWith("POST", body: "<b>bold</b>");
+            ctx.Request.Path = "/api/richtext/save";
+            await middleware.InvokeAsync(ctx);
+
+            Assert.That(nextCalled, Is.True);
+        }
+
+        [Test]
+        public async Task Honors_Custom_Response()
+        {
+            var opts = new PayloadInjectionMiddlewareOptions
+            {
+                ResponseStatusCode = 422,
+                ResponseContentType = "application/json",
+                ResponseContentBody = "{\"error\":\"nope\"}"
+            };
+            var middleware = Build(opts, _ => Task.CompletedTask);
+
+            var ctx = ContextWith("PUT", body: "a;b");
+            await middleware.InvokeAsync(ctx);
+
+            ctx.Response.Body.Position = 0;
+            var written = await new StreamReader(ctx.Response.Body).ReadToEndAsync();
+
+            Assert.That(ctx.Response.StatusCode, Is.EqualTo(422));
+            Assert.That(ctx.Response.ContentType, Is.EqualTo("application/json"));
+            Assert.That(written, Is.EqualTo("{\"error\":\"nope\"}"));
+        }
+
+        [Test]
+        public async Task Rejects_Oversized_Body_With_413()
+        {
+            var opts = new PayloadInjectionMiddlewareOptions { MaxScannedBodyBytes = 4 };
+            var middleware = Build(opts, _ => Task.CompletedTask);
+
+            var ctx = ContextWith("POST", body: "this body is definitely longer than four bytes");
+            await middleware.InvokeAsync(ctx);
+
+            Assert.That(ctx.Response.StatusCode, Is.EqualTo(413));
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -4,15 +4,30 @@ A reusable payload injection filter for ASP.NET Core. This can be used to short-
 [![Build/Test Workflow](https://github.com/bsaranga/PayloadInjectionFilter/actions/workflows/dotnet-build.yml/badge.svg)](https://github.com/bsaranga/PayloadInjectionFilter/actions/workflows/dotnet-build.yml)
 [![Nuget Package Publish Workflow](https://github.com/bsaranga/PayloadInjectionFilter/actions/workflows/dotnet-publish.yml/badge.svg)](https://github.com/bsaranga/PayloadInjectionFilter/actions/workflows/dotnet-publish.yml)
 
-Available on [NuGet](https://www.nuget.org/packages/Zone24x7.PayloadInjectionFilter/)
+Available on [NuGet](https://www.nuget.org/packages/SpitFire.PayloadInjectionFilter/)
+
+The package ships **two interchangeable mechanisms**:
+
+| | MVC Action Filter | Middleware |
+|---|---|---|
+| Method | `AddPayloadInjectionFilter` | `AddPayloadInjectionMiddleware` / `UsePayloadInjectionMiddleware` |
+| Runs | after model binding | before routing & model binding |
+| Sees | the bound model object graph | the raw query string and request body |
+| Covers | MVC controllers only | controllers, **minimal APIs**, Razor Pages, gRPC |
+| Granularity | per-property white-listing | per-path exclusion |
+
+Use the **filter** when you want property-level white-listing inside MVC controllers. Use the **middleware** when you want a single boundary check that covers every endpoint type (including minimal APIs) and runs before any binding cost is incurred. They can also be combined.
 
 ## Features
 
 1. Pattern based detection of malicious strings in JSON payloads
-2. Specify the HTTP methods on which the filter should execute
+2. Specify the HTTP methods on which the filter/middleware should execute
 3. Specify the short-circuit response by setting status code, content type and body
-4. Supports recursive payloads, including recursion limit specification
-5. Specific properties in specific endpoints can be white-listed
+4. Supports recursive payloads, including recursion limit specification, with built-in protection against cyclic object graphs
+5. Specific properties in specific endpoints can be white-listed (filter), or whole paths excluded (middleware)
+6. Optional per-entry `ExclusionPattern` that still rejects disallowed content inside otherwise white-listed properties
+
+> **Scope — read this first.** This is a *defense-in-depth* boundary check, not a complete security control. Deny-listing characters such as `< > & ;` does **not** by itself protect against XSS or SQL injection — the real defenses remain output encoding (Razor auto-encoding, `HtmlEncoder`) and parameterized queries / an ORM. Deny-listing will also reject some legitimate input (names with `&`, rich-text fields, etc.); white-list those properties or exclude those paths. Treat this library as one cheap layer in front of those primary defenses, not a replacement for a WAF.
 
 ## Usage
 
@@ -133,3 +148,92 @@ cfg.WhiteListEntries = new List<WhiteListEntry>
     }
 };
 ```
+
+A white-listed property is normally skipped entirely. If you want to allow *most* content in a property but still block a narrower set of patterns, set an `ExclusionPattern` on the entry. The property is exempt from the global `Pattern`, but the request is still short-circuited when the value matches the `ExclusionPattern`:
+
+```csharp
+cfg.WhiteListEntries = new List<WhiteListEntry>
+{
+    new WhiteListEntry
+    {
+        PathTemplate = "api/Services/appointmentSettings/{id}",
+        ParameterName = "appointmentSetting",
+        PropertyNames = new List<string>
+        {
+            nameof(ServiceAppointmentSetting.AdditoinalInformation)
+        },
+        // Rich text with <p>, <strong> etc. is allowed, but <script> is still rejected.
+        ExclusionPattern = new Regex("<script", RegexOptions.IgnoreCase)
+    }
+};
+```
+
+## Using the middleware
+
+The middleware inspects the **raw** query string and request body before model binding, so it protects every endpoint type — including minimal APIs and Razor Pages — not just MVC controllers. Register the options in service configuration and add the middleware early in the pipeline:
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddPayloadInjectionMiddleware(cfg =>
+{
+    cfg.AllowedHttpMethods = new List<HttpMethod>
+    {
+        HttpMethod.Post,
+        HttpMethod.Put,
+        HttpMethod.Patch,
+    };
+
+    cfg.Pattern = new Regex(@"[<>\&;]");
+});
+
+var app = builder.Build();
+
+// Place it before UseRouting / MapControllers so malicious requests are
+// short-circuited before reaching any endpoint.
+app.UsePayloadInjectionMiddleware();
+
+app.MapControllers();
+app.MapPost("/minimal", (SomeModel model) => Results.Ok()); // also covered
+
+app.Run();
+```
+
+Because the middleware works on raw text it has no concept of model properties. Instead of per-property white-listing it supports **per-path exclusions** and toggles for what to scan:
+
+```csharp
+builder.Services.AddPayloadInjectionMiddleware(cfg =>
+{
+    cfg.Pattern = new Regex(@"[<>\&;]");
+
+    // Custom short-circuit response (defaults: 400, text/plain, standard message).
+    cfg.ResponseStatusCode = 400;
+    cfg.ResponseContentType = "application/json";
+    cfg.ResponseContentBody = JsonSerializer.Serialize(new { Error = "Malicious content found" });
+
+    // Choose what is scanned (both default to true).
+    cfg.ScanQueryString = true;
+    cfg.ScanBody = true;
+
+    // Bodies larger than this are rejected with 413 instead of being buffered (default 30 MB).
+    cfg.MaxScannedBodyBytes = 30L * 1024 * 1024;
+
+    // Routes that legitimately accept markup / rich text bypass scanning (prefix match).
+    cfg.ExcludedPaths = new List<PathString>
+    {
+        "/api/content/richtext"
+    };
+});
+```
+
+Notes:
+
+- The query string is URL-decoded before matching, so percent-encoded payloads such as `%3Cscript%3E` are caught.
+- The request body is buffered (`EnableBuffering`) and rewound, so downstream endpoints can read it as normal.
+- Only the HTTP methods in `AllowedHttpMethods` are scanned (POST, PUT, PATCH by default).
+
+## Reliability notes
+
+- **Cyclic object graphs** (e.g. `a.Nested = b; b.Nested = a;`) are detected via reference tracking on the traversal path, so the filter no longer stack-overflows when `MaxRecursionDepth` is left at the default `-1`.
+- **Null action arguments** (optional / unbound parameters and null collection items) are skipped instead of throwing.
+- Reflection metadata (`PropertyInfo`) is cached per type, so repeated requests do not re-enumerate properties on every call.

--- a/TestAPI/Program.cs
+++ b/TestAPI/Program.cs
@@ -1,5 +1,5 @@
 using System.Text.RegularExpressions;
-using Zone24x7PayloadExtensionFilter;
+using SpitFirePayloadExtensionFilter;
 
 namespace TestAPI
 {


### PR DESCRIPTION
## Summary

Adds a middleware-based alternative to the MVC action filter, fixes several latent crash/perf bugs in the existing filter, and rebrands the package from Zone24x7 to SpitFire.

## Filter hardening
- Skip null action arguments and null collection items instead of throwing (optional/unbound parameters no longer 500 the request)
- Reference-based, path-scoped **cycle detection** so cyclic object graphs terminate instead of stack-overflowing at the default infinite recursion depth
- Read each property value once instead of up to three `GetValue` calls
- Cache `PropertyInfo` per type to avoid re-reflecting on every request
- Guard `AttributeRouteInfo` for convention-routed controllers
- Wire up the previously-dead `WhiteListEntry.ExclusionPattern`

## New: request-scanning middleware
`PayloadInjectionMiddleware` runs before model binding and scans the raw query string and request body, so it covers **minimal APIs, Razor Pages and gRPC** in addition to MVC controllers.
- `AddPayloadInjectionMiddleware` / `UsePayloadInjectionMiddleware` helpers
- Method gating, per-path exclusions, query/body scan toggles
- URL-decodes the query string to catch percent-encoded payloads
- Buffers and rewinds the body so downstream endpoints can re-read it
- Rejects bodies larger than `MaxScannedBodyBytes` with 413

## Rebrand
- Namespace `Zone24x7PayloadExtensionFilter` → `SpitFirePayloadExtensionFilter`
- PackageId `Zone24x7.PayloadInjectionFilter` → `SpitFire.PayloadInjectionFilter`
- Version bumped to `0.1.0`

> Note: the new PackageId means the next publish creates a **new** NuGet listing rather than versioning the old one.

## Docs
- Filter-vs-middleware comparison and middleware usage section
- Documented the now-functional `ExclusionPattern`
- Honest scope note (defense-in-depth, not a WAF / output-encoding replacement)
- Reliability notes (cycle safety, null handling, caching)

## Tests
31 → **41 passing**. New tests cover null arguments, cyclic graphs, `ExclusionPattern`, and the full middleware surface (body/query short-circuit, body rewind, method gating, path exclusion, custom response, oversized 413).

🤖 Generated with [Claude Code](https://claude.com/claude-code)